### PR TITLE
Improve performance

### DIFF
--- a/LoggingDecoratorGenerator.IntegrationTests/InformationLevelInterfaceTests.cs
+++ b/LoggingDecoratorGenerator.IntegrationTests/InformationLevelInterfaceTests.cs
@@ -137,7 +137,7 @@ public class InformationLevelInterfaceTests
 
         // Assert
         A.CallTo(() => _fakeService.MethodShouldNotBeLoggedBecauseOfLogLevel()).MustHaveHappenedOnceExactly();
-        A.CallTo(() => fakeLogger.IsEnabled(LogLevel.Information)).MustHaveHappenedTwiceExactly();
+        A.CallTo(() => fakeLogger.IsEnabled(LogLevel.Information)).MustHaveHappenedOnceExactly();
         A.CallTo(fakeLogger).Where(call => call.Method.Name == nameof(ILogger.Log)).MustNotHaveHappened();
     }
 

--- a/LoggingDecoratorGenerator.IntegrationTests/LoggingDecoratorGenerator.IntegrationTests.csproj
+++ b/LoggingDecoratorGenerator.IntegrationTests/LoggingDecoratorGenerator.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+	<TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/LoggingDecoratorGenerator.Tests/GeneratorSnapshotTests.GeneratesCorrectly#SomeServiceLoggingDecorator.g.verified.cs
+++ b/LoggingDecoratorGenerator.Tests/GeneratorSnapshotTests.GeneratesCorrectly#SomeServiceLoggingDecorator.g.verified.cs
@@ -3,7 +3,7 @@
 
 namespace SomeFolder.SomeSubFolder
 {
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Fineboym.Logging.Generator", "1.8.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Fineboym.Logging.Generator", "1.9.0.0")]
     public sealed class SomeServiceLoggingDecorator : ISomeService
     {
         private readonly global::Microsoft.Extensions.Logging.ILogger<ISomeService> _logger;
@@ -31,16 +31,18 @@ namespace SomeFolder.SomeSubFolder
 
         public void VoidParameterlessMethod()
         {
-            global::System.Diagnostics.Stopwatch? __stopwatch = null;
-            if (_logger.IsEnabled(global::Microsoft.Extensions.Logging.LogLevel.Trace))
+            var __logEnabled = _logger.IsEnabled(global::Microsoft.Extensions.Logging.LogLevel.Trace);
+            global::System.Int64 __startTimestamp = 0;
+            if (__logEnabled)
             {
                 s_beforeVoidParameterlessMethod(_logger, null);
-                __stopwatch = global::System.Diagnostics.Stopwatch.StartNew();
+                __startTimestamp = global::System.Diagnostics.Stopwatch.GetTimestamp();
             }
             _decorated.VoidParameterlessMethod();
-            if (_logger.IsEnabled(global::Microsoft.Extensions.Logging.LogLevel.Trace))
+            if (__logEnabled)
             {
-                s_afterVoidParameterlessMethod(_logger, __stopwatch?.Elapsed.TotalMilliseconds, null);
+                var __elapsedTime = global::System.Diagnostics.Stopwatch.GetElapsedTime(__startTimestamp);
+                s_afterVoidParameterlessMethod(_logger, __elapsedTime.TotalMilliseconds, null);
             }
         }
 
@@ -60,12 +62,13 @@ namespace SomeFolder.SomeSubFolder
 
         public int IntReturningMethod(int x, global::OtherFolder.OtherSubFolder.Person person)
         {
-            if (_logger.IsEnabled(global::Microsoft.Extensions.Logging.LogLevel.Debug))
+            var __logEnabled = _logger.IsEnabled(global::Microsoft.Extensions.Logging.LogLevel.Debug);
+            if (__logEnabled)
             {
                 s_beforeIntReturningMethod(_logger, x, person, null);
             }
             var __result = _decorated.IntReturningMethod(x, person);
-            if (_logger.IsEnabled(global::Microsoft.Extensions.Logging.LogLevel.Debug))
+            if (__logEnabled)
             {
                 s_afterIntReturningMethod(_logger, __result, null);
             }
@@ -88,12 +91,13 @@ namespace SomeFolder.SomeSubFolder
 
         public async global::System.Threading.Tasks.Task TaskReturningAsyncMethod(int x, int y)
         {
-            if (_logger.IsEnabled(global::Microsoft.Extensions.Logging.LogLevel.Debug))
+            var __logEnabled = _logger.IsEnabled(global::Microsoft.Extensions.Logging.LogLevel.Debug);
+            if (__logEnabled)
             {
                 s_beforeTaskReturningAsyncMethod(_logger, x, y, null);
             }
             await _decorated.TaskReturningAsyncMethod(x, y).ConfigureAwait(false);
-            if (_logger.IsEnabled(global::Microsoft.Extensions.Logging.LogLevel.Debug))
+            if (__logEnabled)
             {
                 s_afterTaskReturningAsyncMethod(_logger, null);
             }
@@ -115,12 +119,13 @@ namespace SomeFolder.SomeSubFolder
 
         public async global::System.Threading.Tasks.Task<int> TaskIntReturningAsyncMethod(int x, int y)
         {
-            if (_logger.IsEnabled(global::Microsoft.Extensions.Logging.LogLevel.Debug))
+            var __logEnabled = _logger.IsEnabled(global::Microsoft.Extensions.Logging.LogLevel.Debug);
+            if (__logEnabled)
             {
                 s_beforeTaskIntReturningAsyncMethod(_logger, x, y, null);
             }
             var __result = await _decorated.TaskIntReturningAsyncMethod(x, y).ConfigureAwait(false);
-            if (_logger.IsEnabled(global::Microsoft.Extensions.Logging.LogLevel.Debug))
+            if (__logEnabled)
             {
                 s_afterTaskIntReturningAsyncMethod(_logger, __result, null);
             }
@@ -143,12 +148,13 @@ namespace SomeFolder.SomeSubFolder
 
         public async global::System.Threading.Tasks.ValueTask ValueTaskReturningAsyncMethod(int x, int y)
         {
-            if (_logger.IsEnabled(global::Microsoft.Extensions.Logging.LogLevel.Debug))
+            var __logEnabled = _logger.IsEnabled(global::Microsoft.Extensions.Logging.LogLevel.Debug);
+            if (__logEnabled)
             {
                 s_beforeValueTaskReturningAsyncMethod(_logger, x, y, null);
             }
             await _decorated.ValueTaskReturningAsyncMethod(x, y).ConfigureAwait(false);
-            if (_logger.IsEnabled(global::Microsoft.Extensions.Logging.LogLevel.Debug))
+            if (__logEnabled)
             {
                 s_afterValueTaskReturningAsyncMethod(_logger, null);
             }
@@ -170,12 +176,13 @@ namespace SomeFolder.SomeSubFolder
 
         public async global::System.Threading.Tasks.ValueTask<float> ValueTaskFloatReturningAsyncMethod(int x, int y)
         {
-            if (_logger.IsEnabled(global::Microsoft.Extensions.Logging.LogLevel.Debug))
+            var __logEnabled = _logger.IsEnabled(global::Microsoft.Extensions.Logging.LogLevel.Debug);
+            if (__logEnabled)
             {
                 s_beforeValueTaskFloatReturningAsyncMethod(_logger, x, y, null);
             }
             var __result = await _decorated.ValueTaskFloatReturningAsyncMethod(x, y).ConfigureAwait(false);
-            if (_logger.IsEnabled(global::Microsoft.Extensions.Logging.LogLevel.Debug))
+            if (__logEnabled)
             {
                 s_afterValueTaskFloatReturningAsyncMethod(_logger, __result, null);
             }

--- a/LoggingDecoratorGenerator/DecoratorClass.cs
+++ b/LoggingDecoratorGenerator/DecoratorClass.cs
@@ -267,6 +267,8 @@ internal class DecoratorClass
 
     public string ClassName { get; }
 
+    public bool SomeMethodMeasuresDuration { get; }
+
     public DecoratorClass(string @namespace, string interfaceName, string declaredAccessibility, string logLevel, IReadOnlyList<MethodToGenerate> methods)
     {
         Namespace = @namespace;
@@ -275,5 +277,6 @@ internal class DecoratorClass
         LogLevel = logLevel;
         Methods = methods;
         ClassName = $"{(interfaceName[0] == 'I' ? interfaceName.Substring(1) : interfaceName)}LoggingDecorator";
+        SomeMethodMeasuresDuration = methods.Any(static m => m.MeasureDuration);
     }
 }

--- a/LoggingDecoratorGenerator/DecoratorGenerator.cs
+++ b/LoggingDecoratorGenerator/DecoratorGenerator.cs
@@ -51,7 +51,7 @@ public class DecoratorGenerator : IIncrementalGenerator
         foreach (var decoratorClass in decoratorClasses)
         {
             context.CancellationToken.ThrowIfCancellationRequested();
-            string source = SourceGenerationHelper.GenerateLoggingDecoratorClass(decoratorClass);
+            string source = SourceGenerationHelper.GenerateLoggingDecoratorClass(decoratorClass, p.StopwatchGetElapsedTimeAvailable);
             context.AddSource(hintName: $"{decoratorClass.ClassName}.g.cs", sourceText: SourceText.From(text: source, encoding: Encoding.UTF8));
         }
     }

--- a/LoggingDecoratorGenerator/Fineboym.Logging.Generator.csproj
+++ b/LoggingDecoratorGenerator/Fineboym.Logging.Generator.csproj
@@ -8,7 +8,7 @@
 		<LangVersion>Latest</LangVersion>
 		<EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
 		<GeneratePackageOnBuild>False</GeneratePackageOnBuild>
-		<Version>1.8.0</Version>
+		<Version>1.9.0</Version>
 		<Authors>dfineboym</Authors>
 		<Company></Company>
 		<EnableNETAnalyzers>True</EnableNETAnalyzers>

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ This will create a generated class named `SomeServiceLoggingDecorator` in the sa
 
 namespace SomeFolder.SomeSubFolder
 {
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Fineboym.Logging.Generator", "1.8.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Fineboym.Logging.Generator", "1.9.0.0")]
     public sealed class SomeServiceLoggingDecorator : ISomeService
     {
         private readonly global::Microsoft.Extensions.Logging.ILogger<ISomeService> _logger;
@@ -84,12 +84,13 @@ namespace SomeFolder.SomeSubFolder
 
         public int SomeMethod(global::System.DateTime someDateTime)
         {
-            if (_logger.IsEnabled(global::Microsoft.Extensions.Logging.LogLevel.Debug))
+            var __logEnabled = _logger.IsEnabled(global::Microsoft.Extensions.Logging.LogLevel.Debug);
+            if (__logEnabled)
             {
                 s_beforeSomeMethod(_logger, someDateTime, null);
             }
             var __result = _decorated.SomeMethod(someDateTime);
-            if (_logger.IsEnabled(global::Microsoft.Extensions.Logging.LogLevel.Debug))
+            if (__logEnabled)
             {
                 s_afterSomeMethod(_logger, __result, null);
             }
@@ -112,16 +113,18 @@ namespace SomeFolder.SomeSubFolder
 
         public async global::System.Threading.Tasks.Task<double?> SomeAsyncMethod(string? s)
         {
-            global::System.Diagnostics.Stopwatch? __stopwatch = null;
-            if (_logger.IsEnabled(global::Microsoft.Extensions.Logging.LogLevel.Information))
+            var __logEnabled = _logger.IsEnabled(global::Microsoft.Extensions.Logging.LogLevel.Information);
+            global::System.Int64 __startTimestamp = 0;
+            if (__logEnabled)
             {
                 s_beforeSomeAsyncMethod(_logger, s, null);
-                __stopwatch = global::System.Diagnostics.Stopwatch.StartNew();
+                __startTimestamp = global::System.Diagnostics.Stopwatch.GetTimestamp();
             }
             var __result = await _decorated.SomeAsyncMethod(s).ConfigureAwait(false);
-            if (_logger.IsEnabled(global::Microsoft.Extensions.Logging.LogLevel.Information))
+            if (__logEnabled)
             {
-                s_afterSomeAsyncMethod(_logger, __result, __stopwatch?.Elapsed.TotalMilliseconds, null);
+                var __elapsedTime = global::System.Diagnostics.Stopwatch.GetElapsedTime(__startTimestamp);
+                s_afterSomeAsyncMethod(_logger, __result, __elapsedTime.TotalMilliseconds, null);
             }
             return __result;
         }
@@ -142,7 +145,8 @@ namespace SomeFolder.SomeSubFolder
 
         public async global::System.Threading.Tasks.Task<string> AnotherAsyncMethod(int x)
         {
-            if (_logger.IsEnabled(global::Microsoft.Extensions.Logging.LogLevel.Debug))
+            var __logEnabled = _logger.IsEnabled(global::Microsoft.Extensions.Logging.LogLevel.Debug);
+            if (__logEnabled)
             {
                 s_beforeAnotherAsyncMethod(_logger, x, null);
             }
@@ -161,7 +165,7 @@ namespace SomeFolder.SomeSubFolder
                     "AnotherAsyncMethod failed");
                 throw;
             }
-            if (_logger.IsEnabled(global::Microsoft.Extensions.Logging.LogLevel.Debug))
+            if (__logEnabled)
             {
                 s_afterAnotherAsyncMethod(_logger, __result, null);
             }
@@ -184,12 +188,13 @@ namespace SomeFolder.SomeSubFolder
 
         public string GetMySecretString(string username, string password)
         {
-            if (_logger.IsEnabled(global::Microsoft.Extensions.Logging.LogLevel.Debug))
+            var __logEnabled = _logger.IsEnabled(global::Microsoft.Extensions.Logging.LogLevel.Debug);
+            if (__logEnabled)
             {
                 s_beforeGetMySecretString(_logger, username, null);
             }
             var __result = _decorated.GetMySecretString(username, password);
-            if (_logger.IsEnabled(global::Microsoft.Extensions.Logging.LogLevel.Debug))
+            if (__logEnabled)
             {
                 s_afterGetMySecretString(_logger, null);
             }


### PR DESCRIPTION
Improve performance by removing `Stopwatch` allocation and check `ILogger.IsEnabled` once per method call instead of twice.